### PR TITLE
Gracefully handle empty strings

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -111,5 +111,7 @@ Handlebars.registerHelper('rgb', function(str) {
 
 // swaps errornous chars with '-'
 Handlebars.registerHelper('escape', function(str) {
-  return str.replace(/:|;|\\|\//, '-')
+  if (str)
+    return str.replace(/:|;|\\|\//, '-');
+  return str;
 });


### PR DESCRIPTION
This small change makes sure that even if there is an empty string passed to the handlebars escape helper.
